### PR TITLE
composer: release hardlock for minor version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "nette/reflection": "~2.2.0"
+        "nette/reflection": "~2.2"
     },
     "suggest": {
         "ext-curl": "*"


### PR DESCRIPTION
It's better to lock down major version, not minor. Before, Nette 2.3 could not be used.
